### PR TITLE
Fix: Bug when having two videos on the same page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "videojs-shuttle-controls",
+  "name": "@adsignal/videojs-shuttle-controls",
   "version": "1.2.4",
   "description": "Adds shuttle controls(JKL controls) to video.js",
   "main": "dist/videojs-shuttle-controls.cjs.js",
@@ -17,7 +17,6 @@
     "clean": "shx rm -rf ./dist ./test/dist",
     "postclean": "shx mkdir -p ./dist ./test/dist",
     "docs": "npm-run-all docs:*",
-    "docs:api": "jsdoc src -g plugins/markdown -r -d docs/api",
     "docs:toc": "doctoc --notitle README.md",
     "lint": "vjsstandard",
     "server": "karma start scripts/karma.conf.js --singleRun=false --auto-watch",
@@ -94,7 +93,6 @@
   },
   "devDependencies": {
     "@videojs/generator-helpers": "~1.0.0",
-    "jsdoc": "BrandonOCasey/jsdoc#feat/plugin-from-cli",
     "karma": "^4.0.0",
     "rollup": "^1.10.0",
     "sinon": "^7.2.2",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -122,18 +122,20 @@ class ShuttleControls extends Plugin {
     const buttonDom = videojs.dom.$('.vjs-play-control');
     const techDom = videojs.dom.$('.vjs-tech');
     const playControlHandler = () => {
-      const hasPaused = videojs.dom.hasClass(techDom.parentNode, 'vjs-paused');
-      const currentPlaybackRate = this.currentPlaybackRate;
-      const isNegativePlaying = this.isPlaying && currentPlaybackRate < 0 && hasPaused;
-      const isNegativePause = !this.isPlaying && currentPlaybackRate < 0 && hasPaused;
-      const isPositivePlaying = this.isPlaying && currentPlaybackRate > 0 && !hasPaused;
-      const isPositivePause = !this.isPlaying && currentPlaybackRate > 0 && hasPaused;
+      if (this.parentElement.parentElement.id == _this2.player.id_) {
+        const hasPaused = videojs.dom.hasClass(techDom.parentNode, 'vjs-paused');
+        const currentPlaybackRate = this.currentPlaybackRate;
+        const isNegativePlaying = this.isPlaying && currentPlaybackRate < 0 && hasPaused;
+        const isNegativePause = !this.isPlaying && currentPlaybackRate < 0 && hasPaused;
+        const isPositivePlaying = this.isPlaying && currentPlaybackRate > 0 && !hasPaused;
+        const isPositivePause = !this.isPlaying && currentPlaybackRate > 0 && hasPaused;
 
-      if (isNegativePlaying || isPositivePlaying) {
-        this._playPause();
-      }
-      if (isNegativePause || isPositivePause) {
-        this._play(currentPlaybackRate);
+        if (isNegativePlaying || isPositivePlaying) {
+          this._playPause();
+        }
+        if (isNegativePause || isPositivePause) {
+          this._play(currentPlaybackRate);
+        }
       }
     };
 


### PR DESCRIPTION
## Problem: 

When having two video in the same page, playing one of the two automatically plays the other at the same time

## Fix:

After the fix, when playing a specific file it only plays that individual file