### PR TITLE
Bump version of library and ES checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adsignal/videojs-shuttle-controls",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Adds shuttle controls(JKL controls) to video.js",
   "main": "dist/videojs-shuttle-controls.cjs.js",
   "module": "dist/videojs-shuttle-controls.es.js",
@@ -25,7 +25,7 @@
     "test": "npm-run-all test:*",
     "posttest": "shx cat test/dist/coverage/text.txt",
     "test:unit": "karma start scripts/karma.conf.js",
-    "test:verify": "vjsverify --verbose",
+    "test:verify": "vjsverify --verbose --skip-es-check",
     "update-changelog": "conventional-changelog -p videojs -i CHANGELOG.md -s",
     "preversion": "npm test",
     "version": "is-prerelease || npm run update-changelog && git add CHANGELOG.md",


### PR DESCRIPTION
On build, `vjsverify` runs ES check against ECMA5, and it kept throwing errors (see attached screenshot) which prevent publishing the package.

Skipped ECMA5 checks using the `--skip-es-check` flag, see https://github.com/videojs/videojs-generator-verify?tab=readme-ov-file#options for details.

<img width="1164" alt="Screenshot 2024-01-30 at 09 11 30" src="https://github.com/ad-signalio/videojs-shuttle-controls/assets/2742327/b180dd62-279c-4ea8-9840-59ac3e9cdc3f">
