### PR TITLE
Use `videojs.obj.merge` instead of deprecated `videojs.mergeOption`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adsignal/videojs-shuttle-controls",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Adds shuttle controls(JKL controls) to video.js",
   "main": "dist/videojs-shuttle-controls.cjs.js",
   "module": "dist/videojs-shuttle-controls.es.js",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -60,7 +60,7 @@ class ShuttleControls extends Plugin {
     // the parent class will add player under this.player
     super(player);
 
-    this.options = videojs.mergeOptions(defaults, options);
+    this.options = videojs.obj.merge(defaults, options);
 
     this.player.ready(() => {
       this.player.addClass('vjs-shuttle-controls');


### PR DESCRIPTION
Use `videojs.obj.merge` instead of deprecated `videojs.mergeOption` and bump version

https://videojs.com/guides/videojs-7-to-8/#deprecations

Tested using normal TCH video player and TCH parent/child comparison.

To test locally, fetch the repository, run `yarn build` then in your TCH project run:
```
yarn add [path-to-the-local-repo-folder]
```

Then spin up TCH and test.